### PR TITLE
Add init_db, close_db to session.py, lifespan to main.py

### DIFF
--- a/src/database/models/accounts.py
+++ b/src/database/models/accounts.py
@@ -20,7 +20,7 @@ from sqlalchemy.orm import (
     relationship,
 )
 
-from base import Base
+from database.models.base import Base
 
 
 class UserGroupEnum(str, enum.Enum):

--- a/src/database/models/movies.py
+++ b/src/database/models/movies.py
@@ -11,7 +11,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import mapped_column, Mapped, relationship
 
-from base import Base
+from database.models.base import Base
 
 
 MoviesGenresModel = Table(

--- a/src/database/session.py
+++ b/src/database/session.py
@@ -1,19 +1,45 @@
 from pathlib import Path
 from typing import AsyncGenerator
 
-from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
+
+from database.models.base import Base
+
 
 BASE_DIR = Path(__file__).parent.parent
 PATH_TO_DB = str(BASE_DIR / "database" / "cinema.db")
 
 SQLITE_DATABASE_URL = f"sqlite+aiosqlite:///{PATH_TO_DB}"
 sqlite_engine = create_async_engine(SQLITE_DATABASE_URL, echo=False)
-AsyncSQLiteSessionLocal = sessionmaker(  # type: ignore
+AsyncSQLiteSessionLocal = async_sessionmaker(
     bind=sqlite_engine,
-    class_=AsyncSession,
     expire_on_commit=False
 )
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:
     async with AsyncSQLiteSessionLocal() as session:
         yield session
+
+
+async def init_db() -> None:
+    """
+    Initialize the database.
+
+    This function creates all tables defined in the SQLAlchemy ORM models.
+    It should be called at the application startup to ensure that the database schema exists.
+    """
+    from database.models import accounts, movies
+
+
+    async with sqlite_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+async def close_db() -> None:
+    """
+    Close the database connection.
+
+    This function disposes of the database engine, releasing all associated resources.
+    It should be called when the application shuts down to properly close the connection pool.
+    """
+    await sqlite_engine.dispose()

--- a/src/database/session.py
+++ b/src/database/session.py
@@ -3,8 +3,8 @@ from typing import AsyncGenerator
 
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
 
+from database.models import accounts, movies
 from database.models.base import Base
-
 
 BASE_DIR = Path(__file__).parent.parent
 PATH_TO_DB = str(BASE_DIR / "database" / "cinema.db")
@@ -28,9 +28,6 @@ async def init_db() -> None:
     This function creates all tables defined in the SQLAlchemy ORM models.
     It should be called at the application startup to ensure that the database schema exists.
     """
-    from database.models import accounts, movies
-
-
     async with sqlite_engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,8 @@
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 
+from database.session import init_db, close_db
 from routes import (
     movie_router,
     accounts_router,
@@ -8,8 +11,17 @@ from routes import (
     shopping_cart_router
 )
 
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await init_db()
+    yield
+    await close_db()
+
+
 app = FastAPI(
     title="Online Cinema",
+    lifespan=lifespan,
 )
 
 api_version_prefix = "/api"


### PR DESCRIPTION
Add lifespan to call init_db on application startup

Use absolute imports in accounts and movies

I had to manually import our models to session, so that their metadata is loaded

As this thing was used only in first hw, and later the db is initialized differently, maybe **we shouldn't merge this**

But to test that the models are created without errors - this will do fine